### PR TITLE
Remove dead 'claimed' greying-out code and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,13 +18,19 @@ Each item is labeled with a colored category pill:
 - **drink** (amber) — alcoholic and non-alcoholic drinks
 - **cover** (purple) — show tickets
 
-## Claimed items
-
-Items marked as already claimed are **greyed out** with a strikethrough and a `claimed` label. They cannot be selected. This is used when someone has already paid for a specific item and it should be excluded from further splitting.
-
 ## Auto-select
 
-The first unclaimed show ticket is automatically selected when the page loads, since every guest owes the cover charge. You can deselect it if needed.
+The first show ticket is automatically selected when the page loads, since every guest owes the cover charge. You can deselect it if needed.
+
+## Limitations
+
+This is a **static HTML file with no backend**. There is no server, database, or shared state between users. Each person who opens the page gets a fresh copy — selections made by one person are invisible to everyone else.
+
+Because of this, there is no "greyed out / claimed" functionality. The concept would be: once someone pays for an item, it gets greyed out so others can't accidentally select it too. But making that work would require:
+
+1. **A backend or database** (e.g. Firebase, Supabase, a simple API) to persist which items have been claimed.
+2. **Real-time sync** so that when one user claims items, every other open browser tab updates automatically (via WebSockets or polling).
+3. **A clear trigger point** — the most natural moment to mark items as claimed is when the Venmo button is tapped, but Venmo provides no payment confirmation callback, so the app would have to trust that the user actually paid.
 
 ## Bill-splitting logic
 

--- a/index.html
+++ b/index.html
@@ -280,24 +280,7 @@
   .cat-drink-pill { background: #2a1e10; color: #e8a020; }
   .cat-cover-pill { background: #1e1a2a; color: #9580c8; }
 
-  .item-row.claimed {
-    opacity: 0.38;
-    cursor: not-allowed;
-  }
 
-  .item-row.claimed .item-name {
-    text-decoration: line-through;
-    color: var(--muted);
-  }
-
-  .item-row.claimed::after {
-    content: 'claimed';
-    font-size: 8px;
-    color: var(--muted);
-    letter-spacing: 0.1em;
-    text-transform: uppercase;
-    flex-shrink: 0;
-  }
 </style>
 </head>
 <body>
@@ -550,7 +533,6 @@
   const VENMO = 'ilia-kudryavtsev';
 
   function toggle(el) {
-    if (el.classList.contains('claimed')) return;
     el.classList.toggle('selected');
     update();
   }
@@ -594,14 +576,9 @@
     btn.textContent = `Pay Ilia · ${fmt(grandTotal)}`;
   }
 
-  // Apply claimed state for any items marked data-claimed="true"
-  document.querySelectorAll('.item-row[data-claimed="true"]').forEach(el => {
-    el.classList.add('claimed');
-  });
-
-  // Auto-select the first non-claimed Show Ticket on page load
+  // Auto-select the first Show Ticket on page load
   const firstTicket = Array.from(document.querySelectorAll('.item-row')).find(
-    el => el.querySelector('.cat-cover-pill') && !el.classList.contains('claimed')
+    el => el.querySelector('.cat-cover-pill')
   );
   if (firstTicket) {
     firstTicket.classList.add('selected');


### PR DESCRIPTION
The claimed/greyed-out feature (CSS, JS toggle guard, and data-claimed initialisation) was never triggered — no items had data-claimed="true" and there is no backend to set that state. Removed all related code.

Updated README to remove the Claimed items section and replace it with a Limitations section explaining why greying out doesn't work and what would be needed to implement it.